### PR TITLE
defaultQueryの挙動を修正

### DIFF
--- a/src/components/molecules/SearchForm.tsx
+++ b/src/components/molecules/SearchForm.tsx
@@ -25,7 +25,7 @@ const SearchForm = (props: SearchFormProps) => {
   }
 
   useEffect(() => {
-    setSearchKeyword(defaultQuery);
+    defaultQuery && setSearchKeyword(defaultQuery);
   }, [defaultQuery])
 
   return (


### PR DESCRIPTION
# defaultQuery
- defaultQueryがnullの状態でuseEffect内でsetSearchKeyword<string>にdefaultQueryを入れようとしたので怒られた
- defaultQueryが存在するときのみsetSearchKeywordを実行するようにした